### PR TITLE
Updated to v2 url

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub use crate::page::PageOptions;
 pub use crate::streaming_api::StreamingApiExt;
 
 /// The static host address for the API.
-pub const API_HOST: &str = "https://api.soundcloud.com";
+pub const API_HOST: &str = "https://api-v2.soundcloud.com";
 
 mod apis;
 mod client;


### PR DESCRIPTION
With soundcloud not updaing the legacy api in a number of years and it being impossible to get a key for a while would it be wise to move to the v2 api

Currently 14 of the 22 tests fail in its current state and work is requried to fix them
```
running 22 tests
test test_get_users ... FAILED
test test_get_playlists ... FAILED
test test_search_tracks ... FAILED
test test_fetch_likes ... FAILED
test test_fetch_my_playlists ... FAILED
test test_track_comments ... FAILED
test test_get_user ... ok
test test_get_user_from_permalink ... FAILED
test test_get_track ... ok
test test_download ... FAILED
test test_stream ... FAILED
test test_get_first_page_user_tracks ... ok
test test_track_likers ... FAILED
test test_user_likes ... FAILED
test test_user_web_profile ... FAILED
test test_paginate_user_tracks ... ok
test test_resolve_track ... FAILED
test test_get_playlist ... ok
test test_user_playlists ... FAILED
test test_user_followings ... ok
test test_user_followers ... ok
test test_related_tracks ... ok

```